### PR TITLE
fix: (wip) hls external relay, prefix hls urls with hls+http://.. prefix in ffmpeg input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,12 +2737,14 @@ dependencies = [
  "log",
  "mongodb",
  "parking_lot 0.12.1",
+ "regex_static",
  "serde-util",
  "shutdown",
  "stream-util",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "url",
 ]
 
 [[package]]

--- a/git/hooks/pre-commit-8zahpiew0ex.mjs
+++ b/git/hooks/pre-commit-8zahpiew0ex.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env zx
+
+// zx must be installed on the system to run this
+// install it with `npm i -g zx`
+
+// this pre-commit hook ensure that the repo has the 
+// latest ts definitions as they are generated from cargo test command,
+// without this ci tests on frontend could fail
+// it also ensures that the package-lock files are updated running npm ci on all npm packages
+
+const write = (str) => {
+	process.stdout.write(str);
+}
+
+const writeln = (str) => {
+	process.stdout.write(str + "\n");
+}
+
+const check = () => {
+	writeln(` ${chalk.green("✓")}`);
+}
+
+
+await within(async () => {
+	$.verbose = false;
+	// $.log = (entry) => {
+	// 	if(entry.kind === "cd") {
+	// 		writeln(chalk.green(`${cd} ${entry.dir}`));
+	// 	} else if(entry.kind === "cmd") {
+	// 		writeln(chalk.green(entry.cmd));
+	// 	}
+	// }
+
+	const root = (await $`git rev-parse --show-toplevel`).stdout.trim();
+	cd(root);
+	
+	write(`Cleaning defs directory...`);
+	await $`rm -rf defs`;
+	check();
+
+	write(`Running cargo tests...`);
+	await $`cargo test --color always`;
+	await $`git add defs`
+	check();
+
+	await within(async () => {
+		write(`Running front npm ci...`);
+		cd("front");
+		await $`npm run ci`;
+		await $`git add **/package-lock.json`;
+		await $`git add **/package.json`;
+		check();
+	})
+
+	await within(async () => {
+		write("Running front types sync...");
+		
+		await within(async () => {
+			cd("front/app")
+			await $`npm run sync`;
+		})
+
+		await within(async () => {
+			cd("front/admin")
+			await $`npm run sync`;
+		})
+		
+		check();
+	})
+
+	writeln("Done!")
+}).catch(e => {
+	writeln("===============");
+	writeln(chalk.red("Error"));
+	writeln("Exit code: ", e.exitCode);
+	writeln("== STDOUT ==")
+	writeln(e.stdout)
+	writeln("== STDERR ==")
+	writeln(e.stderr);
+	writeln("===============");
+	process.exit(1);
+})

--- a/rs/packages/media-sessions/Cargo.toml
+++ b/rs/packages/media-sessions/Cargo.toml
@@ -20,9 +20,11 @@ hyper = { version = "0.14.26", features = ["full"] }
 log = "0.4.17"
 mongodb = "2.4.0"
 parking_lot = "0.12.1"
+regex_static = "0.1.1"
 serde-util = { version = "0.1.0", path = "../serde-util" }
 shutdown = { version = "0.1.0", path = "../shutdown" }
 stream-util = { version = "0.1.0", path = "../stream-util" }
 thiserror = "1.0.38"
 tokio = { version = "1.27.0", features = ["full"] }
 tokio-stream = "0.1.11"
+url = "2.4.0"

--- a/rs/packages/media-sessions/src/external_relay.rs
+++ b/rs/packages/media-sessions/src/external_relay.rs
@@ -32,7 +32,7 @@ pub enum LiveError {
   ExitNotOk { stderr: String },
 }
 
-pub fn run_external_releay_session(
+pub fn run_external_relay_session(
   tx: Transmitter,
   deployment_id: String,
   url: String,
@@ -85,8 +85,19 @@ pub fn run_external_releay_session(
         drop_tracer.token(),
       )));
 
+      let ffmpeg_url = match url::Url::parse(&url) {
+        Err(_) => url,
+        Ok(u) => {
+          if u.path().ends_with(".m3u") || u.path().ends_with(".m3u8") {
+            format!("hls+{url}")
+          } else {
+            url
+          }
+        }
+      };
+
       let ffmpeg_config = FfmpegConfig {
-        input: Some(url),
+        input: Some(ffmpeg_url),
         kbitrate: STREAM_KBITRATE,
         ..FfmpegConfig::default()
       };

--- a/rs/packages/stream/src/lib.rs
+++ b/rs/packages/stream/src/lib.rs
@@ -13,7 +13,7 @@ use hyper::header::{HeaderName, ACCEPT_RANGES, CACHE_CONTROL, RETRY_AFTER};
 use hyper::{header::CONTENT_TYPE, http::HeaderValue, Body, Server, StatusCode};
 use ip_counter::IpCounter;
 use log::*;
-use media_sessions::external_relay::run_external_releay_session;
+use media_sessions::external_relay::run_external_relay_session;
 use media_sessions::playlist::run_playlist_session;
 use media_sessions::relay::run_relay_session;
 use media_sessions::RecvError;
@@ -564,7 +564,7 @@ impl StreamHandler {
 
                     tokio::spawn(async move {
                       let _ =
-                        run_external_releay_session(tx, deployment_id, url, shutdown, drop_tracer)
+                        run_external_relay_session(tx, deployment_id, url, shutdown, drop_tracer)
                           .await
                           .unwrap();
                       drop(dropper);


### PR DESCRIPTION
Apparently prefixing hls urls in ffmpeg with hls+ causes ffmpeg to use hls protocol instead the hls demuxer, hls protocol seems to work better than hls demuxer.